### PR TITLE
Update impfuzzy_util.c

### DIFF
--- a/pyimpfuzzy/impfuzzy_util.c
+++ b/pyimpfuzzy/impfuzzy_util.c
@@ -1,3 +1,5 @@
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <fuzzy.h>
 #include <unistd.h>


### PR DESCRIPTION
Defining `PY_SSIZE_T_CLEAN` macro to fix https://github.com/JPCERTCC/impfuzzy/issues/7

Python's documentation on the change can be found here -> https://docs.python.org/3/c-api/arg.html

```
For all # variants of formats (s#, y#, etc.), the macro PY_SSIZE_T_CLEAN must be defined before including Python.h. On Python 3.9 and older, the type of the length argument is [Py_ssize_t](https://docs.python.org/3/c-api/intro.html#c.Py_ssize_t) if the PY_SSIZE_T_CLEAN macro is defined, or int otherwise.
```

Testing on 3.10.5 using
```
$docker run -ti --rm fedora:latest bash
```

```python
# python3
Python 3.10.5 (main, Jun  9 2022, 00:00:00) on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyimpfuzzy
>>> contents = open('helloworld.exe','rb').read()
>>> pyimpfuzzy.get_impfuzzy_data(contents)
'24:wyWPWyWNwUxQSySPXQDMLaocAzAZhDbBSy29fJLhJCBAihTK4Tg9kBb+u5Fi119p:gCNhQSVXQwLwAYunPuBS1119L9'
```

Testing back to 3.6 using
```bash
$docker run -ti --rm ubuntu:bionic bash
```
```python
# python3
Python 3.6.9 (default, Mar 15 2022, 13:55:28) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyimpfuzzy
>>> contents = open('helloworld.exe','rb').read()
>>> pyimpfuzzy.get_impfuzzy_data(contents)
'24:wyWPWyWNwUxQSySPXQDMLaocAzAZhDbBSy29fJLhJCBAihTK4Tg9kBb+u5Fi119p:gCNhQSVXQwLwAYunPuBS1119L9'
```